### PR TITLE
Add keyCode to key event callback

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,7 +15,7 @@ $ npm install keylogger.js
 ## Usage
 
 ```ts
-import keylogger from "keylogger.js";
+import * as keylogger from "keylogger.js";
 // or
 // const keylogger = require("keylogger.js");
 

--- a/src/index.d.ts
+++ b/src/index.d.ts
@@ -3,7 +3,7 @@ capture key down and up events
 
 @example
 ```
-import keylogger from "keylogger.js";
+import * as keylogger from "keylogger.js";
 
 keylogger.start((key, isKeyUp) => {
   console.log("keyboard event", key, isKeyUp);
@@ -15,8 +15,9 @@ keylogger.start((key, isKeyUp) => {
  * Start listening to keyboard events
  * key: will match KeyboardEvent.key value as listed in this table https://developer.mozilla.org/en-US/docs/Web/API/KeyboardEvent/key/Key_Values
  * isKeyUp: `true` if the key is up, `false` otherwise
+ * keyCode: numerical code representing the value of the pressed key
  */
-export const start: (callback: (key: string, isKeyUp: boolean) => void) => void;
+export const start: (callback: (key: string, isKeyUp: boolean, keyCode: number) => void) => void;
 
 /**
  * Stop listening to keyboard events

--- a/src/index.d.ts
+++ b/src/index.d.ts
@@ -5,8 +5,8 @@ capture key down and up events
 ```
 import * as keylogger from "keylogger.js";
 
-keylogger.start((key, isKeyUp) => {
-  console.log("keyboard event", key, isKeyUp);
+keylogger.start((key, isKeyUp, keyCode) => {
+  console.log("keyboard event", key, isKeyUp, keyCode);
 });
 ```
 */

--- a/src/macOS/keylogger.mm
+++ b/src/macOS/keylogger.mm
@@ -85,7 +85,8 @@ void Start(const Napi::CallbackInfo &info) {
 
             napi_status status = tsfn.BlockingCall([=](Napi::Env env, Napi::Function jsCallback) {
                 jsCallback.Call({Napi::String::New(env, ConvertKeyCodeToString(keyCode)),
-                                 Napi::Boolean::New(env, isKeyUp)});
+                                 Napi::Boolean::New(env, isKeyUp),
+                                 Napi::Number::New(env, keyCode)});
             });
             if (status != napi_ok) {
                 std::cerr << "Failed to execute BlockingCall!" << std::endl;

--- a/src/windows/keylogger.cc
+++ b/src/windows/keylogger.cc
@@ -80,7 +80,8 @@ void Start(const Napi::CallbackInfo &info) {
                       tsfn.BlockingCall([=](Napi::Env env, Napi::Function jsCallback) {
                           jsCallback.Call(
                             {Napi::String::New(env, ConvertKeyCodeToString(kbdStruct.vkCode)),
-                             Napi::Boolean::New(env, wParam == WM_KEYUP || wParam == WM_SYSKEYUP)});
+                             Napi::Boolean::New(env, wParam == WM_KEYUP || wParam == WM_SYSKEYUP),
+                             Napi::Number::New(env, kbdStruct.vkCode)});
                       });
                     if (status != napi_ok) {
                         std::cerr << "Failed to execute BlockingCall!" << std::endl;

--- a/test.js
+++ b/test.js
@@ -1,7 +1,7 @@
 const keylogger = require("./src/index");
 
-keylogger.start((key, isKeyUp) => {
-  console.log("key event", key, isKeyUp);
+keylogger.start((key, isKeyUp, keyCode) => {
+  console.log("key event", key, isKeyUp, keyCode);
 });
 
 setTimeout(() => {


### PR DESCRIPTION
Key code is useful when the key does not map to any string, such as media keys.
Also fixes example typescript code because keylogger does not export any default.
**I have not tested the mac version, only windows.**